### PR TITLE
Document per-API and per-tag slice layout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,39 @@
 # Klaviyo's OpenAPI Specification
 
-This repo contains versioned copies of our [OpenAPI spec](openapi/stable.json).
+Versioned [OpenAPI specs](openapi/stable.json) for the Klaviyo API. Same source we use for [API docs](https://developers.klaviyo.com/en/reference/) and our [SDKs](https://developers.klaviyo.com/en/docs/sdk_overview).
 
-This is the same spec we use to generate our [API Docs](https://developers.klaviyo.com/en/reference/), as well as our latest [SDKs](https://developers.klaviyo.com/en/docs/sdk_overview).
+## Layout
 
-You can find the general spec (and soon, SDK/language-specific specs) in the `openapi` folder
+| Path | Contents | Use it when |
+|---|---|---|
+| `openapi/stable.json` | Full GA spec (~2.5 MB, all operations across all categories) | SDK codegen, full validation, anything needing the complete surface |
+| `openapi/stable/categories/{category}.json` | Per-category slice — e.g. `forms.json`, `profiles.json`, `templates.json`, `reporting.json` | Grounding an LLM against a single category; partner integrations scoped to one category |
+| `openapi/stable/apis/{operationId}.json` | Per-endpoint slice — e.g. `create_form.json`, `get_profile.json` | Tooling that operates on a single endpoint at a time |
+| `openapi/beta.json` and `openapi/beta/{categories,apis}/...` | Same layout for pre-release endpoints | Testing forthcoming APIs before GA |
 
-You can find our [LEGACY spec here](https://klaviyo-openapi.s3.amazonaws.com/spec.json).
+`operationId` matches the [developer portal](https://developers.klaviyo.com/en/reference/) URL slug 1:1 — `/en/reference/create_form` ↔ `openapi/stable/apis/create_form.json`.
+
+## LLM agents — use the per-category slice
+
+The full spec is too large for many WebFetch-style tools to consume reliably. Per-category slices (~50–200 KB) are self-contained OpenAPI 3 documents with all referenced components inlined and `$ref` semantics preserved.
+
+Examples:
+
+- Forms → `openapi/stable/categories/forms.json`
+- Templates → `openapi/stable/categories/templates.json`
+- Profiles → `openapi/stable/categories/profiles.json`
+
+Raw URLs (for `curl`, WebFetch, or grounding tools):
+
+```
+https://raw.githubusercontent.com/klaviyo/openapi/main/openapi/stable/categories/forms.json
+https://raw.githubusercontent.com/klaviyo/openapi/main/openapi/stable/apis/create_form.json
+```
+
+## Revisions
+
+Each API revision (e.g. `2026-04-15`) lives on its own branch. The `main` branch tracks the latest GA revision.
+
+## Legacy
+
+Legacy spec: https://klaviyo-openapi.s3.amazonaws.com/spec.json


### PR DESCRIPTION
## Dependencies (must merge first)

This README points at paths that don't exist yet. The PR that publishes those paths must merge before this one:

- The slicer pipeline change in our internal CI tooling repo. Once that merges and a `publish-oas` build completes, the URLs in this README will return 200 and this PR is safe to merge.

## Summary

Document the per-operation and per-category slice layout that the upcoming pipeline change is adding to this repo. LLM agents and tooling get an explicit pointer at slices instead of the 2.5 MB monolith.

## Why

Once the slicer pipeline ships, this repo will contain three artifacts at three sizes:

- `openapi/stable.json` — full GA spec (~2.5 MB)
- `openapi/stable/categories/{category}.json` — per-category slice (~50–200 KB)
- `openapi/stable/apis/{operationId}.json` — per-endpoint slice (~5–200 KB)

Plus beta equivalents. None of this is mentioned in today's README. New visitors (human or agent) default to the monolith because that's all they see.

## What changes

README now has:

- A layout table: which file, what it contains, when to use it
- The `operationId` ↔ developer-portal URL slug mapping
- An LLM-specific section pointing at per-category slices with raw GitHub URLs
- A revisions note (per-revision branches, `main` tracks latest GA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
